### PR TITLE
Neovim: update autocmds.lua

### DIFF
--- a/dot_config/nvim/lua/config/autocmds.lua
+++ b/dot_config/nvim/lua/config/autocmds.lua
@@ -1,3 +1,10 @@
 -- Autocmds are automatically loaded on the VeryLazy event
 -- Default autocmds that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/autocmds.lua
 -- Add any additional autocmds here
+
+vim.api.nvim_create_autocmd({ "BufEnter", "BufWinEnter" }, {
+  pattern = { "dot_bashrc" },
+  callback = function()
+    vim.bo.filetype = "sh"
+  end,
+})


### PR DESCRIPTION
Create an autocmd to set filetype `sh` to `dot_bashrc`.